### PR TITLE
add empty var snippet

### DIFF
--- a/snippets/django-snippets.json
+++ b/snippets/django-snippets.json
@@ -8,6 +8,13 @@
             "{% endcomment %}"
         ]
     },
+    "var": {
+        "prefix": "var",
+        "description": "Empty Var",
+        "body": [
+            "{{ $1 }}"
+        ]
+    },
     "tag": {
         "prefix": "tag",
         "description": "Empty tag",


### PR DESCRIPTION
Add a new snippet to use django variables. Typing **"var"** the snippet will inject **"{{ 
$1 }}"**. 
I've started using  vscode  a few weeks ago and I think it is necessary to include it. In SublimeText there is a similar snippet in SublimeText and this feature is very useful. Regards!