### PR TITLE
Don't redefine the html language 

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,10 +27,9 @@
     "contributes": {
         "languages": [
             {
-                "id": "html",
+                "id": "django-html",
                 "aliases": [
-                    "Django Template",
-                    "HTML"
+                    "Django Template"
                 ],
                 "extensions": [".html", ".htm"],
                 "configuration": "./django-html.configuration.json"
@@ -38,14 +37,14 @@
         ],
         "grammars": [
             {
-                "language": "html",
+                "language": "django-html",
                 "scopeName": "text.html.django",
                 "path": "./syntaxes/django-html.json"
             }
         ],
         "snippets": [
             {
-                "language": "html",
+                "language": "django-html",
                 "scopeName": "text.html.django",
                 "path": "./snippets/django-snippets.json"
             }


### PR DESCRIPTION
See https://github.com/Microsoft/vscode/issues/26408#issuecomment-301029077: Redefining the html language and giving it a new name causes confusion. A better way is to define a separate language. The django language will be the default language for the .html, but ideally there would be a way to detect of file is html or django-html. 
 
Oh, and please enable Issues in your github repo so issues like this can be files.... Thanks a lot!