### PR TITLE
Allow notes in comments and keep highlight

### DIFF
--- a/syntaxes/django-html.json
+++ b/syntaxes/django-html.json
@@ -20,7 +20,7 @@
             "name": "comment.line.django"
         },
         {
-            "begin": "{% comment %}",
+            "begin": "{% comment",
             "captures": [
                 {
                     "name": "entity.other.django.delimiter.comment"


### PR DESCRIPTION
This is to allow the following:
```
    {% comment "Optional note" %}
        something
    {% endcomment %}
```